### PR TITLE
boot-args fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+DerivedData
+project.xcworkspace
+xcuserdata


### PR DESCRIPTION
Here is a change that helped me update Catalina to 10.15.7. The patch does not replace boot-args NVRAM variable. It will append to it or create it if necessary.